### PR TITLE
more robust way to obtain phantomjs pid

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -211,14 +211,15 @@ phantom <- function (pjs_cmd = "", port = 4444L, extras = "", ...){
   }else{
     system2(pjsPath, pjsargs, wait = FALSE, ...)
     if(Sys.info()["sysname"] == "Darwin"){
-      pjsPID <- system('ps -Ao"pid,args"', intern = TRUE)
-      pjsPID <- sub("^\\s*(\\d+)(.*)", "\\1,\\2", pjsPID)
-      pjsPID <- read.csv(text = pjsPID[-1], stringsAsFactors = FALSE, header = FALSE) 
-      names(pjsPID) <- c("PID", "COMMAND")       
+      pids <- system('ps -Ao"pid"', intern = TRUE)
+      args <- system('ps -Ao"args"', intern = TRUE)
     }else{
-      pjsPID <- read.csv(text = system('ps -Ao"%p,%a"', intern = TRUE), stringsAsFactors = FALSE)        
+      pids <- system('ps -Ao"%p"', intern = TRUE)
+      args <- system('ps -Ao"%a"', intern = TRUE)
     }
-    pjsPID <- as.integer(pjsPID$PID[grepl("phantomjs", pjsPID$COMMAND)])
+    idx <- grepl("phantomjs", args)
+    if(!any(idx)) warning("Couldn't find the phantomjs process")
+    pjsPID <- pids[idx]
   }
   
   list(


### PR DESCRIPTION
The [current approach to obtaining process IDs on non-windows machines](https://github.com/ropensci/RSelenium/blob/master/R/util.R#L211-L221) will result in error if the process argument string contains any `,`s. For example, I have a use case where I see:

```r
> system("ps -Ao\"%p,%a\"", intern = TRUE)
[1] "  PID,COMMAND"                                                                                                                                                    
[2] "    1,/bin/bash"                                                                                                                                                  
[3] "  145,/usr/lib/R/bin/exec/R"                                                                                                                                      
[4] "  148,/usr/lib/R/bin/exec/R --slave --no-restore -e library(methods);~+~cat(Sys.getpid(),~+~file=\"/pipeline/animint/tests/testthat/pids.txt\",~+~sep=\"\\\\n\",~"
[5] "  159,/usr/local/bin/phantomjs --webdriver=4444"                                                                                                                  
[6] "  173,sh -c ps -Ao\"%p,%a\""                                                                                                                                      
[7] "  174,ps -Ao%p,%a"                                                                                                                                                

> read.csv(text = system("ps -Ao\"%p,%a\"", intern = TRUE))
Error in read.table(file = file, header = header, sep = sep, quote = quote,  : 
  more columns than column names
```

This pull request will fix that problem.

cc @johndharrison @tdhock