### PR TITLE
Possible error in addCookie(), named parameter instead of named list element

### DIFF
--- a/R/remoteDriver.R
+++ b/R/remoteDriver.R
@@ -594,7 +594,7 @@ remoteDriver <- setRefClass("remoteDriver",
                                 "Set a cookie on the domain. The inputs are required apart from `secure` which defaults to FALSE."
                                 cookie<-list(name = name,value = value,path = path,domain = domain,secure = secure)
                                 queryRD(paste0(serverURL,'/session/',sessionInfo$id,'/cookie'),
-                                        "POST",qdata=toJSON(cookie = list(cookie)))
+                                        "POST",qdata=toJSON(list(cookie = cookie)))
                               },
                               
                               deleteAllCookies = function(){


### PR DESCRIPTION
I believe there might have been an error in the `addCookie()` method. The problem seems to be that instead of supplying a list with an element named "cookie" to `toJSON()`, the current method supplies a function parameter named "cookie" which is a list with an unnamed element. 

With the current github version, the following snippet fails:

    startServer()
    remDr <- remoteDriver(browserName = "firefox")
    remDr$open()
    remDr$navigate("http://cran.r-project.org")
    remDr$addCookie(name = "test", value = "abc123", path = "/", domain = "cran.r-project.org")
    remDr$getAllCookies()

In particular, it produces the following output:

    > startServer()
    > remDr <- remoteDriver(browserName = "firefox")
    > remDr$open()
    [1] "Connecting to remote server"
    $platform
    [1] "LINUX"

    $javascriptEnabled
    [1] TRUE

    $acceptSslCerts
    [1] TRUE

    $browserName
    [1] "firefox"

    $rotatable
    [1] FALSE

    $locationContextEnabled
    [1] TRUE

    $webdriver.remote.sessionid
    [1] "b6f028f5-9a7f-4be1-bffa-595f55235c65"

    $version
    [1] "38.0"

    $databaseEnabled
    [1] TRUE

    $cssSelectorsEnabled
    [1] TRUE

    $handlesAlerts
    [1] TRUE

    $webStorageEnabled
    [1] TRUE

    $nativeEvents
    [1] FALSE

    $applicationCacheEnabled
    [1] TRUE

    $takesScreenshot
    [1] TRUE

    $id
    [1] "b6f028f5-9a7f-4be1-bffa-595f55235c65"

    > remDr$navigate("http://cran.r-project.org")
    > remDr$addCookie(name = "test", value = "abc123", path = "/", domain = "cran.r-project.org")
    Error in toJSON(cookie = list(cookie)) : 
      argument "x" is missing, with no default
    > remDr$getAllCookies()
    list()

With this pull request it seems to run fine:

    > remDr$navigate("http://cran.r-project.org")
    > remDr$addCookie(name = "test", value = "abc123", path = "/", domain = "cran.r-project.org")
    > remDr$getAllCookies()
    [[1]]
    [[1]]$name
    [1] "test"

    [[1]]$path
    [1] "/"

    [[1]]$value
    [1] "abc123"

    [[1]]$secure
    [1] FALSE

    [[1]]$domain
    [1] "cran.r-project.org"

    [[1]]$class
    [1] "org.openqa.selenium.Cookie"

    [[1]]$httpOnly
    [1] FALSE

    [[1]]$hCode
    [1] 3556498

My `sessionInfo()`:

    > sessionInfo()
    R version 3.2.0 (2015-04-16)
    Platform: x86_64-pc-linux-gnu (64-bit)
    Running under: elementary OS Freya

    locale:
     [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=sv_SE.UTF-8        LC_COLLATE=en_US.UTF-8    
     [5] LC_MONETARY=sv_SE.UTF-8    LC_MESSAGES=en_US.UTF-8    LC_PAPER=sv_SE.UTF-8       LC_NAME=C                 
     [9] LC_ADDRESS=C               LC_TELEPHONE=C             LC_MEASUREMENT=sv_SE.UTF-8 LC_IDENTIFICATION=C       

    attached base packages:
    [1] stats     graphics  grDevices utils     datasets  methods   base     

    other attached packages:
    [1] RSelenium_1.3.6 XML_3.98-1.1    RJSONIO_1.3-0   RCurl_1.95-4.6  bitops_1.0-6   

    loaded via a namespace (and not attached):
    [1] tools_3.2.0    caTools_1.17.1
