### PR TITLE
Don't print username/password with server URL

### DIFF
--- a/R/errorHandler.R
+++ b/R/errorHandler.R
@@ -176,7 +176,7 @@ errorHandler <-
         value <<- list()
         eMessage <- list(
           "Invalid call to server. Please check you have opened a browser.",
-          paste0("Couldnt connect to host on ", serverURL, 
+          paste0("Couldnt connect to host on ", obscureUrlPassword(serverURL),
                  ".\n  Please ensure a Selenium server is running."),
           function(x){
             paste0("Undefined error in httr call. httr output: ", x)
@@ -198,6 +198,18 @@ errorHandler <-
                class = statusclass,
                status = status
         )
+      },
+
+      obscureUrlPassword = function(url) {
+        "Replaces the username and password of url with ****"
+        parsedUrl <- httr::parse_url(url)
+        if (!is.null(parsedUrl$username)) {
+            parsedUrl$username <- "****"
+        }
+        if (!is.null(parsedUrl$password)) {
+            parsedUrl$password <- "****"
+        }
+        httr::build_url(parsedUrl)
       }
     )
   )


### PR DESCRIPTION
Closes #128
CC:/ @johndharrison 

New behaviour:
```
> ip <- paste0(user, ':', pass, "@localhost")
> ip
[1] "jstockwin:7bb340bf-e0be-4dc0-9f94-fd4de8e7ec54@localhost"
> remDr <- remoteDriver$new(remoteServerAddr = ip)
> remDr$open()
[1] "Connecting to remote server"
Error in checkError(res) : 
  Couldnt connect to host on http://****:****@localhost:4444/wd/hub.
  Please ensure a Selenium server is running.
```

I've made a new function, `obscureUrlPassword` which I've stuck inside the `errorHandler` class itself. It could easily just be a helper function at the bottom of the file, and obviously can be renamed if you like - let me know!