### PR TITLE
Cache packages after Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 language: R
 services:
 - docker
+cache:
+- packages
 env:
   matrix:
   - NOT_CRAN=true


### PR DESCRIPTION
@johndharrison I noticed the Travis build on my other PR was taking a while because it was re-installing all the packages from scratch. Might be worth caching them? 

"Using the package cache to store R package dependencies can significantly speed up build times and is recommended for most builds." - [docs](https://docs.travis-ci.com/user/languages/r/#Basic-configuration)

Obviously up to you if you want this or not - feel free to close this if you have your reasons for not doing this. 