### PR TITLE
Fix for switchToWindow not working in Edge.

### DIFF
--- a/R/remoteDriver.R
+++ b/R/remoteDriver.R
@@ -751,7 +751,7 @@ remoteDriver <-
         queryRD(qpath, "POST", qdata = list(id = Id))
       },
 
-      switchToWindow = function(windowId) {
+      switchToWindow = function(windowId, use_handle = FALSE) {
         "Change focus to another window. The window to change focus to may
         be specified by its server assigned window handle, or by the value
         of its name attribute."
@@ -759,7 +759,7 @@ remoteDriver <-
           "%s/session/%s/window",
           serverURL, sessionInfo[["id"]]
         )
-        if (browserName == "firefox") {
+        if (browserName == "firefox" | browserName == "MicrosoftEdge" | use_handle) {
           qdata <- list(handle = windowId)
         } else {
           qdata <- list(name = windowId)


### PR DESCRIPTION
Tested with:
```
R version 4.4.1 (2024-06-14 ucrt)
Platform: x86_64-w64-mingw32/x64
Running under: Windows 11 x64 (build 26100)

Selenium Server: 4.0.0-alpha-2

Microsoft Edge
Version 132.0.2957.127 (Official build) (64-bit)
```

`switchToWindow ` was fixed with force to use `qdata <- list(handle = windowId)` option. 

This may be considered to be merged to main branch.
