### PR TITLE
Update documentation to address CRAN notes

### DIFF
--- a/R/remoteDriver.R
+++ b/R/remoteDriver.R
@@ -26,15 +26,15 @@
 #' @field port Object of class \code{"numeric"}, the port of the remote
 #'    server on which to connect
 #' @field browserName Object of class \code{"character"}. The name of the
-#'    browser being used; should be one of {chrome|firefox|htmlunit|
-#'    internet explorer|iphone}.
+#'    browser being used; should be one of \code{{chrome|firefox|htmlunit|
+#'    internet explorer|iphone}}.
 #' @field path base URL path prefix for commands on the remote server.
 #'    Defaults to "/wd/hub"
 #' @field version Object of class \code{"character"}. The browser version,
 #'    or the empty string if unknown.
 #' @field platform Object of class \code{"character"}. A key specifying
 #'    which platform the browser is running on. This value should be one
-#'    of {WINDOWS|XP|VISTA|MAC|LINUX|UNIX}. When requesting a new session,
+#'    of \code{{WINDOWS|XP|VISTA|MAC|LINUX|UNIX}}. When requesting a new session,
 #'    the client may specify ANY to indicate any available platform may be
 #'    used.
 #' @field javascript Object of class \code{"logical"}. Whether the session
@@ -935,9 +935,9 @@ remoteDriver <-
         objects of class WebElement. The inputs are:
         \\describe{
           \\item{\\code{using}:}{Locator scheme to use to search the
-          element, available schemes: {\"class name\", \"css selector\",
+          element, available schemes: \\code{{\"class name\", \"css selector\",
           \"id\", \"name\", \"link text\", \"partial link text\",
-          \"tag name\", \"xpath\" }. Defaults to 'xpath'. Partial string
+          \"tag name\", \"xpath\" }}. Defaults to 'xpath'. Partial string
           matching is accepted. See the findElement method for details}
           \\item{\\code{value}:}{The search target. See examples.}
         }"

--- a/R/util.R
+++ b/R/util.R
@@ -1,4 +1,4 @@
-#' Get Firefox profile.
+#' Get Firefox profile
 #'
 #' \code{getFirefoxProfile}
 #' A utility function to get a firefox profile.
@@ -50,7 +50,7 @@ getFirefoxProfile <- function(profDir, useBase = TRUE) {
   list("firefox_profile" = fireprof)
 }
 
-#' Get Chrome profile.
+#' Get Chrome profile
 #'
 #' \code{getChromeProfile}
 #' A utility function to get a Chrome profile.
@@ -146,7 +146,7 @@ makePrefjs <- function(opts) {
   sprintf("user_pref(\"%s\", %s);", names(opts), optsQuoted)
 }
 
-#' Make Firefox profile.
+#' Make Firefox profile
 #'
 #' \code{makeFirefoxProfile}
 #' A utility function to make a firefox profile.

--- a/R/webElement.R
+++ b/R/webElement.R
@@ -47,10 +47,10 @@ webElement <-
         The inputs are:
         \\describe{
           \\item{\\code{using}:}{Locator scheme to use to search the
-            element, available schemes: {\"class name\", \"css selector\",
+            element, available schemes: \\code{{\"class name\", \"css selector\",
             \"id\", \"name\", \"link text\", \"partial link text\",
             \"tag name\", \"xpath\" }. Defaults to 'xpath'. Partial string
-            matching is accepted.}
+            matching is accepted.}}
           \\item{\\code{value}:}{The search target. See examples.}
         }"
         using <- match.arg(using)
@@ -77,7 +77,7 @@ webElement <-
         The inputs are:
         \\describe{
           \\item{\\code{using}:}{Locator scheme to use to search the
-            element, available schemes: {\"class name\", \"css selector\",
+            element, available schemes: \\code{\"class name\", \"css selector\",
             \"id\", \"name\", \"link text\", \"partial link text\",
             \"tag name\", \"xpath\" }. Defaults to 'xpath'.
             Partial string matching is accepted.}

--- a/man/getChromeProfile.Rd
+++ b/man/getChromeProfile.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util.R
 \name{getChromeProfile}
 \alias{getChromeProfile}
-\title{Get Chrome profile.}
+\title{Get Chrome profile}
 \usage{
 getChromeProfile(dataDir, profileDir)
 }

--- a/man/getFirefoxProfile.Rd
+++ b/man/getFirefoxProfile.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util.R
 \name{getFirefoxProfile}
 \alias{getFirefoxProfile}
-\title{Get Firefox profile.}
+\title{Get Firefox profile}
 \usage{
 getFirefoxProfile(profDir, useBase = TRUE)
 }

--- a/man/makeFirefoxProfile.Rd
+++ b/man/makeFirefoxProfile.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util.R
 \name{makeFirefoxProfile}
 \alias{makeFirefoxProfile}
-\title{Make Firefox profile.}
+\title{Make Firefox profile}
 \usage{
 makeFirefoxProfile(opts)
 }

--- a/man/remoteDriver-class.Rd
+++ b/man/remoteDriver-class.Rd
@@ -36,8 +36,8 @@ ip of the remote server. Defaults to localhost}
 server on which to connect}
 
 \item{\code{browserName}}{Object of class \code{"character"}. The name of the
-browser being used; should be one of {chrome|firefox|htmlunit|
-internet explorer|iphone}.}
+browser being used; should be one of \code{{chrome|firefox|htmlunit|
+internet explorer|iphone}}.}
 
 \item{\code{path}}{base URL path prefix for commands on the remote server.
 Defaults to "/wd/hub"}
@@ -47,7 +47,7 @@ or the empty string if unknown.}
 
 \item{\code{platform}}{Object of class \code{"character"}. A key specifying
 which platform the browser is running on. This value should be one
-of {WINDOWS|XP|VISTA|MAC|LINUX|UNIX}. When requesting a new session,
+of \code{{WINDOWS|XP|VISTA|MAC|LINUX|UNIX}}. When requesting a new session,
 the client may specify ANY to indicate any available platform may be
 used.}
 
@@ -191,9 +191,9 @@ document root. The located elements will be returned as an list of
 objects of class WebElement. The inputs are:
 \describe{
   \item{\code{using}:}{Locator scheme to use to search the
-  element, available schemes: {"class name", "css selector",
+  element, available schemes: \code{{"class name", "css selector",
   "id", "name", "link text", "partial link text",
-  "tag name", "xpath" }. Defaults to 'xpath'. Partial string
+  "tag name", "xpath" }}. Defaults to 'xpath'. Partial string
   matching is accepted. See the findElement method for details}
   \item{\code{value}:}{The search target. See examples.}
 }}

--- a/man/webElement-class.Rd
+++ b/man/webElement-class.Rd
@@ -47,10 +47,10 @@ an object of webElement class.
 The inputs are:
 \describe{
   \item{\code{using}:}{Locator scheme to use to search the
-    element, available schemes: {"class name", "css selector",
+    element, available schemes: \code{{"class name", "css selector",
     "id", "name", "link text", "partial link text",
     "tag name", "xpath" }. Defaults to 'xpath'. Partial string
-    matching is accepted.}
+    matching is accepted.}}
   \item{\code{value}:}{The search target. See examples.}
 }}
 
@@ -64,7 +64,7 @@ returned as an list of objects of class WebElement.
 The inputs are:
 \describe{
   \item{\code{using}:}{Locator scheme to use to search the
-    element, available schemes: {"class name", "css selector",
+    element, available schemes: \code{"class name", "css selector",
     "id", "name", "link text", "partial link text",
     "tag name", "xpath" }. Defaults to 'xpath'.
     Partial string matching is accepted.}


### PR DESCRIPTION
### CRAN notes
```
Version: 1.7.9
Check: Rd files
Result: NOTE 
  checkRd: (-1) remoteDriver-class.Rd:39-40: Lost braces
      39 | browser being used; should be one of {chrome|firefox|htmlunit|
         |                                      ^
  checkRd: (-1) remoteDriver-class.Rd:50: Lost braces; missing escapes or markup?
      50 | of {WINDOWS|XP|VISTA|MAC|LINUX|UNIX}. When requesting a new session,
         |    ^
  checkRd: (-1) remoteDriver-class.Rd:194-196: Lost braces
     194 |   element, available schemes: {"class name", "css selector",
         |                               ^
  checkRd: (-1) webElement-class.Rd:50-52: Lost braces
      50 |     element, available schemes: {"class name", "css selector",
         |                                 ^
  checkRd: (-1) webElement-class.Rd:67-69: Lost braces
      67 |     element, available schemes: {"class name", "css selector",
         |                                 ^
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/RSelenium-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/RSelenium-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/RSelenium-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/RSelenium-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/RSelenium-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/RSelenium-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/RSelenium-00check.html), [r-release-macos-arm64](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/RSelenium-00check.html), [r-release-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/RSelenium-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/RSelenium-00check.html), [r-oldrel-macos-arm64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-arm64/RSelenium-00check.html), [r-oldrel-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/RSelenium-00check.html), [r-oldrel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-windows-x86_64/RSelenium-00check.html)

Version: 1.7.9
Check: for unstated dependencies in ‘demo’
Result: NOTE 
  'library' or 'require' call not declared from: ‘selectr’
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/RSelenium-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/RSelenium-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/RSelenium-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/RSelenium-00check.html)
```

### Context

This task was proposed by R Core developer Kurt Hornik as part of an initiative to improve CRAN package documentation. Packages with public repositories (GitHub, GitLab, Bitbucket) and a higher number of reverse dependencies were prioritised. This PR has been completed as part of an R Dev Day at the University of Warwick on 12 Sept 2025 (see https://github.com/r-devel/r-dev-day/issues/110).